### PR TITLE
Add working default key binding on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
       }
     ],
     "keybindings": [{
-      "key": "cmd+;",
+      "key": "ctrl+;",
+      "mac": "cmd+;",
       "when": "editorTextFocus",
       "command": "extension.trailing-semicolon"
     }]


### PR DESCRIPTION
With the keybinding set to `cmd+;` it ends up as `win+;` on Windows which may not work (it would put a semicolon in the middle of the line). This PR defaults to `ctrl+;` on Windows and still `cmd+;` on Mac.
